### PR TITLE
[BUGFIX] Prevent call of deprecated getPageRenderer() on TSFE

### DIFF
--- a/lib/class.tx_multicolumn_pi_base.php
+++ b/lib/class.tx_multicolumn_pi_base.php
@@ -12,6 +12,7 @@
  */
 
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class tx_multicolumn_pi_base extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
@@ -118,7 +119,12 @@ class tx_multicolumn_pi_base extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                 $resolved = $file;
 
                 if (file_exists($resolved)) {
-                    ($mediaTypeSplit == '.js') ? $GLOBALS['TSFE']->getPageRenderer()->addJsFooterFile($resolved) : $GLOBALS['TSFE']->getPageRenderer()->addCssFile($resolved);
+                    $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+                    if ($mediaTypeSplit === '.js') {
+                        $pageRenderer->addJsFooterFile($resolved);
+                    } else {
+                        $pageRenderer->addCssFile($resolved);
+                    }
                 }
             }
         }

--- a/pi1/class.tx_multicolumn_pi1.php
+++ b/pi1/class.tx_multicolumn_pi1.php
@@ -11,6 +11,9 @@
  * LICENSE file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 class tx_multicolumn_pi1 extends tx_multicolumn_pi_base
 {
     public $prefixId = 'tx_multicolumn_pi1';        // Same as class name
@@ -156,7 +159,7 @@ class tx_multicolumn_pi1 extends tx_multicolumn_pi_base
             if (!empty($this->effectConfiguration['options'])) {
                 $name = 'mullticolumnEffectBox_' . $this->cObj->data['uid'];
                 $code = 'var ' . $name . ' ={' . $this->effectConfiguration['options'] . '};';
-                $GLOBALS['TSFE']->getPageRenderer()->addJsInlineCode($name, $code);
+                GeneralUtility::makeInstance(PageRenderer::class)->addJsInlineCode($name, $code);
             }
             // js files
             if (is_array($this->effectConfiguration['jsFiles.'])) {


### PR DESCRIPTION
As the PageRenderer is a singleton instance, there is no need to call
a getPageRenderer function. Simply initialize and use it.

Resolves: #44 