### PR TITLE
Adding the multicolumn container uid for optional use in the template

### DIFF
--- a/pi1/class.tx_multicolumn_pi1.php
+++ b/pi1/class.tx_multicolumn_pi1.php
@@ -204,7 +204,7 @@ class tx_multicolumn_pi1 extends tx_multicolumn_pi_base
         $listData['content'] = $this->renderListItems('_NO_TABLE', 'column', $listItemData, $this->llPrefixed);
         $listData['makeEqualElementBoxHeight'] = $this->layoutConfiguration['makeEqualElementBoxHeight'];
         $listData['makeEqualElementColumnHeight'] = $this->layoutConfiguration['makeEqualElementColumnHeight'];
-        $listData['uid'] = $this->multicolumnContainerUid;
+        $listData['containerUid'] = $this->multicolumnContainerUid;
 
         return $this->renderItem('columnContainer', $listData);
     }

--- a/pi1/class.tx_multicolumn_pi1.php
+++ b/pi1/class.tx_multicolumn_pi1.php
@@ -204,6 +204,7 @@ class tx_multicolumn_pi1 extends tx_multicolumn_pi_base
         $listData['content'] = $this->renderListItems('_NO_TABLE', 'column', $listItemData, $this->llPrefixed);
         $listData['makeEqualElementBoxHeight'] = $this->layoutConfiguration['makeEqualElementBoxHeight'];
         $listData['makeEqualElementColumnHeight'] = $this->layoutConfiguration['makeEqualElementColumnHeight'];
+        $listData['uid'] = $this->multicolumnContainerUid;
 
         return $this->renderItem('columnContainer', $listData);
     }


### PR DESCRIPTION
There are cases in which the uid is useful in the template. For example by adding a section navigation to the page. And the jumplinks/hashnavigation are dynamically created in this format: "c{uid}".