### PR TITLE
[BUGFIX] Remove paste icons in TYPO3 8.7

### DIFF
--- a/res/backend/style.css
+++ b/res/backend/style.css
@@ -32,6 +32,10 @@ table.multicolumn .t3-icon-document-new {
 	margin: 12px 0 0 16px;
 }
 
+table.multicolumn .t3-page-column-header-icons {
+	right: 10px;
+}
+
 ul.contentElements {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
As there is no way to append own parameter to DataHandler actions, it
is not possible to assign the correct container pid for paste icon links.
Therefore the paste icons are removed with this patch. You can still use
the context menu to paste a copied record.

Furthermore this patch adds an addition "Content" button underneath a
record element.

Resolves: #45 