### PR TITLE
Missing line

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,6 +22,7 @@ $EM_CONF[$_EXTKEY] = array (
   'createDirs' => '',
   'clearcacheonload' => 1,
   'version' => '5.0.0',
+  'constraints' =>
   array (
     'depends' =>
     array (


### PR DESCRIPTION
Missing line causes  TYPO3 Exception: #1519931815: The package "multicolumn" depends on "php" which is not present in the system.