### PR TITLE
Bugfix for unused elements message in backend (introduced in TYPO3 9)

### DIFF
--- a/Classes/Hooks/ContentUsedDecision.php
+++ b/Classes/Hooks/ContentUsedDecision.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace IchHabRecht\Multicolumn\Hooks;
+
+
+class ContentUsedDecision
+{
+
+    public function isContentElementUsed(array $parameters): bool
+    {
+        return $parameters['used'] || $parameters['record']['tx_multicolumn_parentid'] !== 0;
+    }
+
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,6 +16,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php'][
     \IchHabRecht\Multicolumn\Hooks\PageLayoutViewHook::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['recStatInfoHooks']['multicolumn'] =
     \IchHabRecht\Multicolumn\Hooks\PageLayoutViewHook::class . '->addDeleteWarning';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['record_is_used']['multicolumn'] =
+    \IchHabRecht\Multicolumn\Hooks\ContentUsedDecision::class . '->isContentElementUsed';
 
 // special eval
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][\IchHabRecht\Multicolumn\Evaluation\MaxColumnsEvaluator::class] = '';


### PR DESCRIPTION
Implemented record_is_used Hook.

See
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Feature-67884-DisplayUnusedCEs.html