### PR TITLE
[BUGFIX] use correct Condition for Languagehandling

### DIFF
--- a/Classes/Controller/ContainerController.php
+++ b/Classes/Controller/ContainerController.php
@@ -18,7 +18,6 @@ namespace IchHabRecht\Multicolumn\Controller;
 use IchHabRecht\Multicolumn\Utility\DatabaseUtility;
 use IchHabRecht\Multicolumn\Utility\FlexFormUtility;
 use IchHabRecht\Multicolumn\Utility\MulticolumnUtility;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -129,7 +128,6 @@ class ContainerController extends AbstractController
         $LLkey = (!empty($this->LOCAL_LANG[$this->LLkey])) ? $this->LLkey : 'default';
         $this->llPrefixed = MulticolumnUtility::prefixArray($this->LOCAL_LANG[$LLkey], 'lll:');
         $this->pi_setPiVarDefaults();
-
 
         // Check if sys_language_contentOL or getLegacyOverlayType is set and take $this->cObj->data['_LOCALIZED_UID']
         if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version(), '9.4.0', '>=')) {

--- a/Classes/Controller/ContainerController.php
+++ b/Classes/Controller/ContainerController.php
@@ -130,10 +130,17 @@ class ContainerController extends AbstractController
         $this->llPrefixed = MulticolumnUtility::prefixArray($this->LOCAL_LANG[$LLkey], 'lll:');
         $this->pi_setPiVarDefaults();
 
-        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
 
-        // Check if sys_language_contentOL is set and take $this->cObj->data['_LOCALIZED_UID']
-        if ($languageAspect->getLegacyOverlayType() && $languageAspect->getId() && $this->cObj->data['_LOCALIZED_UID']) {
+        // Check if sys_language_contentOL or getLegacyOverlayType is set and take $this->cObj->data['_LOCALIZED_UID']
+        if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version(), '9.4.0', '>=')) {
+            /** @var \TYPO3\CMS\Core\Context\LanguageAspect $languageAspect */
+            $languageAspect = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Context\Context::class)->getAspect('language');
+            $isLocalizedRecord = $languageAspect->getId() && $languageAspect->getLegacyOverlayType();
+        } else {
+            $isLocalizedRecord = $GLOBALS['TSFE']->sys_language_uid && $GLOBALS['TSFE']->sys_language_contentol;
+        }
+
+        if ($isLocalizedRecord && $this->cObj->data['_LOCALIZED_UID']) {
             $this->multicolumnContainerUid = $this->cObj->data['_LOCALIZED_UID'];
         } else {
             // take default uid from cObj->data

--- a/Classes/Controller/ContainerController.php
+++ b/Classes/Controller/ContainerController.php
@@ -18,6 +18,7 @@ namespace IchHabRecht\Multicolumn\Controller;
 use IchHabRecht\Multicolumn\Utility\DatabaseUtility;
 use IchHabRecht\Multicolumn\Utility\FlexFormUtility;
 use IchHabRecht\Multicolumn\Utility\MulticolumnUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -129,8 +130,10 @@ class ContainerController extends AbstractController
         $this->llPrefixed = MulticolumnUtility::prefixArray($this->LOCAL_LANG[$LLkey], 'lll:');
         $this->pi_setPiVarDefaults();
 
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+
         // Check if sys_language_contentOL is set and take $this->cObj->data['_LOCALIZED_UID']
-        if ($GLOBALS['TSFE']->sys_language_contentOL && $GLOBALS['TSFE']->sys_language_uid && $this->cObj->data['_LOCALIZED_UID']) {
+        if ($languageAspect->getLegacyOverlayType() && $languageAspect->getId() && $this->cObj->data['_LOCALIZED_UID']) {
             $this->multicolumnContainerUid = $this->cObj->data['_LOCALIZED_UID'];
         } else {
             // take default uid from cObj->data


### PR DESCRIPTION
with Version 9.4 of TYPO3 the old way to get Languageproperties are deprecated and removed in TYPO3 Version 10.
So the Condition for proper handle translated Content is not working in Version 10.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85543-Language-relatedPropertiesInTypoScriptFrontendControllerAndPageRepository.html?highlight=sys_language_contentol