### PR TITLE
Fix multicolumn issue on translation modes

### DIFF
--- a/Classes/Controller/ContainerController.php
+++ b/Classes/Controller/ContainerController.php
@@ -129,8 +129,12 @@ class ContainerController extends AbstractController
         $this->llPrefixed = MulticolumnUtility::prefixArray($this->LOCAL_LANG[$LLkey], 'lll:');
         $this->pi_setPiVarDefaults();
 
+        $context = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Context\Context::class);
+        $currentLanguageUid = $context->getPropertyFromAspect('language', 'id');
+        $legacyOverlayType = $context->getPropertyFromAspect('language', 'legacyOverlayType');
+
         // Check if sys_language_contentOL is set and take $this->cObj->data['_LOCALIZED_UID']
-        if ($GLOBALS['TSFE']->sys_language_contentOL && $GLOBALS['TSFE']->sys_language_uid && $this->cObj->data['_LOCALIZED_UID']) {
+        if ($legacyOverlayType && $currentLanguageUid && $this->cObj->data['_LOCALIZED_UID']) {
             $this->multicolumnContainerUid = $this->cObj->data['_LOCALIZED_UID'];
         } else {
             // take default uid from cObj->data


### PR DESCRIPTION
Tested on a multilanguage TYPO3 Version 10+ page:

The multicolumn Container is displayed, but not the entries within the container.

This is because the multicolumn extension uses obsolete variables and therefore there is a fallback to the parent language.

We have replaced them with the new related core functions.

More infos: https://stackoverflow.com/questions/5257437/typo3-get-the-current-language-in-an-external-php-file